### PR TITLE
Fix condition order

### DIFF
--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/PathQueryCondition.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/PathQueryCondition.kt
@@ -17,8 +17,8 @@ data class PathQueryCondition(
 ) : HttpUrlCondition() {
 
     override fun compareTo(other: Condition) = when {
-        other is PathQueryCondition && score > other.score -> -1
         other == this -> 0
+        other is PathQueryCondition && score > other.score -> -1
         else -> 1
     }
 

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/PathQueryCondition.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/PathQueryCondition.kt
@@ -18,6 +18,7 @@ data class PathQueryCondition(
 
     override fun compareTo(other: Condition) = when {
         other == this -> 0
+        other is PathQueryCondition && score == other.score -> path.compareTo(other.path)
         other is PathQueryCondition && score > other.score -> -1
         else -> 1
     }

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/PathQueryConditionTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/PathQueryConditionTest.kt
@@ -113,4 +113,109 @@ class PathQueryConditionTest {
     fun `equals and hashCode match contract`() {
         EqualsVerifier.forClass(PathQueryCondition::class.java).verify()
     }
+
+    @Test
+    fun `compareTo should return 0 when conditions are equals without parameters`() {
+        assertThat(suffixPathQueryCondition.compareTo(suffixPathQueryCondition)).isEqualTo(0)
+    }
+
+    @Test
+    fun `compareTo should return 0 when conditions are equals with parameter name`() {
+        assertThat(parameterNamePathQueryCondition.compareTo(parameterNamePathQueryCondition))
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun `compareTo should return 0 when conditions are equals with parameter value`() {
+        assertThat(parameterValuePathQueryCondition.compareTo(parameterValuePathQueryCondition))
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun `compareTo should return a number lower than 0 when conditions are different with the same score and the first condition path is lower than the second`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffix("/abc")
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffix("/cba")
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isLessThan(-1)
+    }
+
+    @Test
+    fun `compareTo should return a number higher than 0 when conditions are different with the same score and the first condition path is higher than the second`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffix("/cba")
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffix("/acb")
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isGreaterThan(0)
+    }
+
+    @Test
+    fun `compareTo should return -1 when the first condition has a parameter name and the second one does not`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffix("/abc")
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(-1)
+    }
+
+    @Test
+    fun `compareTo should return -1 when the first condition has a parameter value and the second one does not`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME, PARAMETER_VALUE)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffix("/abc")
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(-1)
+    }
+
+    @Test
+    fun `compareTo should return -1 when the first condition has a parameter value and the second one has a parameter name`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME, PARAMETER_VALUE)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(-1)
+    }
+
+    @Test
+    fun `compareTo should return 1 when the first condition does not have a parameter and the second one has a parameter name`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffix("/abc")
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `compareTo should return 1 when the first condition has a parameter name and the second one has a parameter value`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME, PARAMETER_VALUE)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `compareTo should return 1 when the first condition does not have a parameter and the second one has a parameter value`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffix("/abc")
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME, PARAMETER_VALUE)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(1)
+    }
 }


### PR DESCRIPTION
Hi to all 👋

I've found a bug when trying to replace a condition (`putResponse`).

The problem is that the responses are sorted by their score and then by equality.

If they have the same score, there is no other property that helps to sort the items.

Imagine you have three responses:
```kotlin
val fixture = FixtureDispatcher
with(PathQueryConditionFactory("/")) {
    fixture.putResponse(withPathSuffix("login"), "login_success")
    fixture.putResponse(withPathSuffix("me"), "me_success")
    fixture.putResponse(withPathSuffix("favourites"), "favourites_success")
}
```

If then we want to replace the `login` path with 
```kotlin
fixture.putResponse(
    PathQueryConditionFactory("/").withPathSuffix("login"),
    "login_failure"
)
```
what happens is that another `login` path item is added at the end of the `constantResponses` of the `FixtureDispatcher`.

**Solution:** by adding these changes, the key is always found when using `put` in the `TreeMap`.

Maybe you could add some tests to check that replacing a response is done successfully.

PD: Thanks for this lib! 🙂 