### PR TITLE
Dependency versions bump

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,7 @@
+
 allprojects {
     repositories {
         mavenCentral()
-        jcenter {
-            content {
-                includeModule("org.jetbrains.kotlinx", "kotlinx-html-jvm")
-            }
-        }
     }
     buildscript {
         repositories {

--- a/dispatcher/build.gradle.kts
+++ b/dispatcher/build.gradle.kts
@@ -1,20 +1,22 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     jacoco
     id("org.jetbrains.kotlin.jvm") version ("1.5.31")
-    id("org.jetbrains.dokka") version ("1.5.30")
+    id("org.jetbrains.dokka") version ("1.5.31")
     id("com.vanniktech.maven.publish") version ("0.18.0")
 }
 
 dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.5.31")
-    implementation("com.squareup.okhttp3:mockwebserver:4.9.1")
+    implementation("com.squareup.okhttp3:mockwebserver:4.9.2")
     implementation("org.apache.commons:commons-text:1.9")
     implementation("org.yaml:snakeyaml:1.29:android")
     testImplementation("org.assertj:assertj-core:3.21.0")
     testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
-    testImplementation("org.mockito:mockito-core:3.12.4")
+    testImplementation("org.mockito:mockito-core:4.0.0")
     testImplementation("junit:junit:4.13.2")
-    testImplementation("nl.jqno.equalsverifier:equalsverifier:3.7.1")
+    testImplementation("nl.jqno.equalsverifier:equalsverifier:3.7.2")
 }
 
 jacoco {
@@ -26,6 +28,17 @@ tasks.jacocoTestReport {
         xml.required.set(true)
         csv.required.set(false)
         html.required.set(true)
+    }
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "11"
     }
 }
 

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/HttpUrlCondition.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/HttpUrlCondition.kt
@@ -9,7 +9,7 @@ import okhttp3.mockwebserver.RecordedRequest
  * Requests without <code>requestUrl</code>s are excluded from matching.
  */
 abstract class HttpUrlCondition : Condition {
-    internal open val httpMethod: HTTPMethod = HTTPMethod.ANY
+    internal open val httpMethod: HTTPMethod get() = HTTPMethod.ANY
 
     override fun isRequestMatching(request: RecordedRequest): Boolean {
         if (httpMethod != HTTPMethod.ANY && request.method != httpMethod.name) {

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/PathQueryConditionTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/PathQueryConditionTest.kt
@@ -2,7 +2,6 @@ package pl.droidsonroids.testing.mockwebserver
 
 import com.nhaarman.mockito_kotlin.mock
 import nl.jqno.equalsverifier.EqualsVerifier
-import nl.jqno.equalsverifier.Warning
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -115,7 +114,6 @@ class PathQueryConditionTest {
     fun `equals and hashCode match contract`() {
         EqualsVerifier
             .forClass(PathQueryCondition::class.java)
-            .suppress(Warning.ALL_FIELDS_SHOULD_BE_USED)
             .verify()
     }
 


### PR DESCRIPTION
Change HttpUrlCondition#httpMethod to property with getter to avoid backing field creation, solves https://github.com/jqno/equalsverifier/issues/506