### PR TITLE
Allow setting fallback response

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ fun factory() {
     dispatcher.enqueue(factory.withPathSuffix("suffix"), "baz")
     // foo will be served by default (if there is nothing enqueued) for subsequent matching requests
     dispatcher.putResponse(factory.withPathSuffix("suffix"), "foo")    
+    // qux will be served by default when there are no matching requests
+    dispatcher.setFallbackResponse("qux")    
     mockWebServer.setDispatcher(dispatcher)
 }
 ```

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcher.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcher.kt
@@ -22,6 +22,7 @@ class FixtureDispatcher internal constructor(private val responseBuilder: Respon
 
     private val constantResponses: MutableMap<Condition, String> = TreeMap()
     private val queuedResponses: MutableMap<Condition, Deque<String>> = TreeMap()
+    private var fallbackResponse: String? = null
 
     /**
      * Called by MockWebServer to determine which response should be returned for given request
@@ -45,6 +46,11 @@ class FixtureDispatcher internal constructor(private val responseBuilder: Respon
                 return responseBuilder.buildMockResponse(fixture)
             }
         }
+
+        fallbackResponse?.let { fallbackResponse ->
+            return responseBuilder.buildMockResponse(fallbackResponse)
+        }
+
         throw IllegalArgumentException("Unexpected request: $request")
     }
 
@@ -67,5 +73,12 @@ class FixtureDispatcher internal constructor(private val responseBuilder: Respon
         val fixtures = queuedResponses[condition] ?: ArrayDeque()
         fixtures += responseFixtureName
         queuedResponses[condition] = fixtures
+    }
+
+    /**
+     * Sets the fallback response when no fixture matches the current existing configured responses.
+     */
+    fun setFallbackResponse(responseFixtureName: String?) {
+        fallbackResponse = responseFixtureName
     }
 }

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherIntegrationTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherIntegrationTest.kt
@@ -25,6 +25,7 @@ class FixtureDispatcherIntegrationTest {
         dispatcher.enqueue(factory.withPathSuffix("suffix"), "json_array")
         dispatcher.putResponse(factory.withPathSuffix("suffix"), "body_path")
         dispatcher.putResponse(factory.withPathSuffix("another_suffix"), "json_object")
+        dispatcher.setFallbackResponse("no_body")
         mockWebServer.dispatcher = dispatcher
 
         val client = OkHttpClient()
@@ -74,6 +75,25 @@ class FixtureDispatcherIntegrationTest {
             .use {
                 assertThat(it.code).isEqualTo(200)
                 assertThat(it.header("Content-Type") == "application/json")
+            }
+
+        val httpUrlWithUnknownSuffix = HttpUrl.Builder()
+            .host(mockWebServer.hostName)
+            .port(mockWebServer.port)
+            .scheme("http")
+            .encodedPath("/prefix/unknown_suffix")
+            .build()
+
+        client.newCall(
+            Request.Builder()
+                .url(httpUrlWithUnknownSuffix)
+                .build()
+        )
+            .execute()
+            .use {
+                assertThat(it.code).isEqualTo(204)
+                assertThat(it.header("Content-Type") == "text/plain")
+                assertThat(it.body.toString() == "")
             }
     }
 

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherTest.kt
@@ -60,4 +60,11 @@ class FixtureDispatcherTest {
         dispatcher.dispatch(request)
         verify(responseBuilder).buildMockResponse("response")
     }
+
+    @Test
+    fun `dispatches fallback response when no matching response found`() {
+        dispatcher.setFallbackResponse("response")
+        dispatcher.dispatch(request)
+        verify(responseBuilder).buildMockResponse("response")
+    }
 }


### PR DESCRIPTION
Hi 👋

I've added the possibility to set a fallback response when no other configured response matches.

This is useful in particular when you want to respond with a default response instead of letting the `FixtureDispatcher` to crash.

It was useful in my case to return a 500 response to all the non-configured requests. Sometimes it's enough for the UI tests instead of letting the MockWebServer crash.

I know that we can use custom Conditions, but it's hard to write that as a fallback response condition as we need to match only the default condition when no other configured paths match. I did it with a whitelist, but it makes more sense to add this feature to the `FeatureDispatcher`.

This is what I use right now to have a default response:
```kotlin
class DefaultCondition : Condition {

    private var whiteList: HashSet<String> = hashSetOf()

    override fun compareTo(other: Condition): Int = -1

    override fun isRequestMatching(request: RecordedRequest): Boolean =
        !whiteList.contains(request.path)

    fun addPathToWhitelist(path: String) {
        whiteList += path
    }
}
```
But if the `whiteList` grows too much, it could have a performance impact on the UI tests.

What do you think about this feature?
