### PR TITLE
Connection failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,13 @@ headers:
 body: body.txt
 ```
 
+You can force the request to fail by setting `connectionFailure` to `true`:
+
+```yaml
+statusCode : 200
+connectionFailure: true
+```
+
 Code without MockWebServer path dispatcher:
 
 ```kotlin

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/Fixture.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/Fixture.kt
@@ -8,6 +8,8 @@ internal class Fixture {
         internal set
     var headers: List<String> = emptyList()
         internal set
+    var connectionFailure: Boolean = false
+        internal set
 
     internal fun hasJsonBody() = body?.isPossibleJson() ?: false
 }

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilder.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilder.kt
@@ -1,6 +1,7 @@
 package pl.droidsonroids.testing.mockwebserver
 
 import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.SocketPolicy
 
 internal class MockResponseBuilder constructor(private val parser: ResourcesParser) :
     ResponseBuilder {
@@ -16,6 +17,10 @@ internal class MockResponseBuilder constructor(private val parser: ResourcesPars
 
         fixture.headers.forEach {
             mockResponse.addHeader(it)
+        }
+
+        if (fixture.connectionFailure) {
+            mockResponse.socketPolicy = SocketPolicy.DISCONNECT_AT_START
         }
 
         return mockResponse

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
@@ -3,6 +3,7 @@ package pl.droidsonroids.testing.mockwebserver
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
+import okhttp3.mockwebserver.SocketPolicy
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
@@ -27,6 +28,7 @@ internal class MockResponseBuilderTest {
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.status).contains("200")
         assertThat(mockResponse.getBody()?.readUtf8()).isEqualTo(body)
+        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
     }
 
     @Test
@@ -38,5 +40,16 @@ internal class MockResponseBuilderTest {
         assertThat(mockResponse.getBody()).isNull()
         assertThat(mockResponse.headers["name"]).isEqualTo("value")
         assertThat(mockResponse.headers["name2"]).isEqualTo("value2")
+        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+    }
+
+    @Test
+    fun `DISCONNECT_AT_START set when connection failure is true`() {
+        fixture.statusCode = 200
+        fixture.connectionFailure = true
+        val mockResponse = builder.buildMockResponse("")
+        assertThat(mockResponse.status).contains("200")
+        assertThat(mockResponse.getBody()).isNull()
+        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.DISCONNECT_AT_START)
     }
 }

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/YamlResourcesParserTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/YamlResourcesParserTest.kt
@@ -29,6 +29,7 @@ class YamlResourcesParserTest {
         assertThat(fixture.statusCode).isEqualTo(200)
         assertThat(fixture.headers).containsOnly("Content-Type: application/json")
         assertThat(fixture.body).isEqualToIgnoringWhitespace("""{"test": null}""")
+        assertThat(fixture.connectionFailure).isFalse
     }
 
     @Test
@@ -37,6 +38,7 @@ class YamlResourcesParserTest {
         assertThat(fixture.statusCode).isEqualTo(200)
         assertThat(fixture.headers).containsOnly("Content-Type: application/json")
         assertThat(fixture.body).isEqualToIgnoringWhitespace("""{"test": "\uD83D\uDC31"}""")
+        assertThat(fixture.connectionFailure).isFalse
     }
 
     @Test
@@ -45,6 +47,7 @@ class YamlResourcesParserTest {
         assertThat(fixture.statusCode).isEqualTo(400)
         assertThat(fixture.headers).isEmpty()
         assertThat(fixture.body).isEqualToIgnoringWhitespace("[]")
+        assertThat(fixture.connectionFailure).isFalse
     }
 
     @Test
@@ -56,6 +59,7 @@ class YamlResourcesParserTest {
             "Vary: Accept-Encoding"
         )
         assertThat(fixture.body).isEqualTo("""{"test"}""")
+        assertThat(fixture.connectionFailure).isFalse
     }
 
     @Test
@@ -67,6 +71,18 @@ class YamlResourcesParserTest {
             "Vary: Accept-Encoding"
         )
         assertThat(fixture.body).isNull()
+        assertThat(fixture.connectionFailure).isFalse
+    }
+
+    @Test
+    fun `parses response with connection failure`() {
+        val fixture = parser.parseFrom("connection_failure")
+        assertThat(fixture.statusCode).isEqualTo(200)
+        assertThat(fixture.headers).containsExactlyInAnyOrder(
+            "Content-Type: text/plain",
+        )
+        assertThat(fixture.body).isNull()
+        assertThat(fixture.connectionFailure).isTrue
     }
 
     @Test

--- a/dispatcher/src/test/resources/fixtures/connection_failure.yaml
+++ b/dispatcher/src/test/resources/fixtures/connection_failure.yaml
@@ -1,0 +1,4 @@
+statusCode: 200
+headers:
+  - 'Content-Type: text/plain'
+connectionFailure:  true


### PR DESCRIPTION
Hello 👋

I've added the possibility to force a response to failing.

This is very useful when we want to test connectivity issues during UI tests.

It's easy to configure with a new parameter in the YAML file called `connectionFailure`.

```yaml
statusCode : 200
connectionFailure: true
```