### PR TITLE
FixtureDispatcher thread safe

### DIFF
--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/YamlResourcesParser.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/YamlResourcesParser.kt
@@ -5,13 +5,12 @@ import org.yaml.snakeyaml.Yaml
 
 internal class YamlResourcesParser : ResourcesParser {
     private val escaper = JavaUnicodeEscaper.above(0xD800)
-    private val parser = Yaml()
 
     override fun parseFrom(fileName: String): Fixture {
         val path = "fixtures/$fileName.yaml"
         val content = path.getResourceAsString()
         val escapedContent = escaper.translate(content)
-        val result = parser.loadAs(escapedContent, Fixture::class.java)
+        val result = Yaml().loadAs(escapedContent, Fixture::class.java)
 
         if (!result.hasJsonBody()) {
             if (result.body != null) {


### PR DESCRIPTION
Hi 👋

I've been having trouble using `FixtureDispatcher` with concurrent code.

I've had two main problems:
- Sometimes the Yaml parser crashes when it's used on concurrent calls. [This](https://github.com/micronaut-projects/micronaut-core/issues/5388) is a similar issue [solved](https://github.com/micronaut-projects/micronaut-core/pull/5467) in another repository.
- Another crash that I was having was when multiple concurrent calls were dequeueing a queued response as `TreeMap` [is not concurrent](https://docs.oracle.com/javase/8/docs/api/java/util/TreeMap.html).

I haven't added any test for this.

What do you think about these changes?
Should we synchronise also the put and queue methods? My fix is only for running the network calls, but there are still issues if we configure the `FixtureDispatcher` from multiple threads.

In my case I need these fixes as sometimes it crashes when doing multiple calls on UI tests or when I test concurrent network calls on integration tests.