### PR TITLE
Timeout failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,13 @@ statusCode : 200
 connectionFailure: true
 ```
 
+Alternatively, you can specify not getting a response by simulating a timeout with `timeoutFailure` to `true`:
+
+```yaml
+statusCode : 200
+timeoutFailure: true
+```
+
 Code without MockWebServer path dispatcher:
 
 ```kotlin

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/Fixture.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/Fixture.kt
@@ -10,6 +10,8 @@ internal class Fixture {
         internal set
     var connectionFailure: Boolean = false
         internal set
+    var timeoutFailure: Boolean = false
+        internal set
 
     internal fun hasJsonBody() = body?.isPossibleJson() ?: false
 }

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilder.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilder.kt
@@ -19,8 +19,13 @@ internal class MockResponseBuilder constructor(private val parser: ResourcesPars
             mockResponse.addHeader(it)
         }
 
-        if (fixture.connectionFailure) {
-            mockResponse.socketPolicy = SocketPolicy.DISCONNECT_AT_START
+        when {
+            fixture.connectionFailure -> {
+                mockResponse.socketPolicy = SocketPolicy.DISCONNECT_AT_START
+            }
+            fixture.timeoutFailure -> {
+                mockResponse.socketPolicy = SocketPolicy.NO_RESPONSE
+            }
         }
 
         return mockResponse

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
@@ -52,4 +52,14 @@ internal class MockResponseBuilderTest {
         assertThat(mockResponse.getBody()).isNull()
         assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.DISCONNECT_AT_START)
     }
+
+    @Test
+    fun `NO_RESPONSE set when timeout failure is true`() {
+        fixture.statusCode = 200
+        fixture.timeoutFailure = true
+        val mockResponse = builder.buildMockResponse("")
+        assertThat(mockResponse.status).contains("200")
+        assertThat(mockResponse.getBody()).isNull()
+        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.NO_RESPONSE)
+    }
 }

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/YamlResourcesParserTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/YamlResourcesParserTest.kt
@@ -30,6 +30,7 @@ class YamlResourcesParserTest {
         assertThat(fixture.headers).containsOnly("Content-Type: application/json")
         assertThat(fixture.body).isEqualToIgnoringWhitespace("""{"test": null}""")
         assertThat(fixture.connectionFailure).isFalse
+        assertThat(fixture.timeoutFailure).isFalse
     }
 
     @Test
@@ -39,6 +40,7 @@ class YamlResourcesParserTest {
         assertThat(fixture.headers).containsOnly("Content-Type: application/json")
         assertThat(fixture.body).isEqualToIgnoringWhitespace("""{"test": "\uD83D\uDC31"}""")
         assertThat(fixture.connectionFailure).isFalse
+        assertThat(fixture.timeoutFailure).isFalse
     }
 
     @Test
@@ -48,6 +50,7 @@ class YamlResourcesParserTest {
         assertThat(fixture.headers).isEmpty()
         assertThat(fixture.body).isEqualToIgnoringWhitespace("[]")
         assertThat(fixture.connectionFailure).isFalse
+        assertThat(fixture.timeoutFailure).isFalse
     }
 
     @Test
@@ -60,6 +63,7 @@ class YamlResourcesParserTest {
         )
         assertThat(fixture.body).isEqualTo("""{"test"}""")
         assertThat(fixture.connectionFailure).isFalse
+        assertThat(fixture.timeoutFailure).isFalse
     }
 
     @Test
@@ -72,6 +76,7 @@ class YamlResourcesParserTest {
         )
         assertThat(fixture.body).isNull()
         assertThat(fixture.connectionFailure).isFalse
+        assertThat(fixture.timeoutFailure).isFalse
     }
 
     @Test
@@ -83,6 +88,19 @@ class YamlResourcesParserTest {
         )
         assertThat(fixture.body).isNull()
         assertThat(fixture.connectionFailure).isTrue
+        assertThat(fixture.timeoutFailure).isFalse
+    }
+
+    @Test
+    fun `parses response with timeout failure`() {
+        val fixture = parser.parseFrom("timeout_failure")
+        assertThat(fixture.statusCode).isEqualTo(200)
+        assertThat(fixture.headers).containsExactlyInAnyOrder(
+                "Content-Type: text/plain",
+        )
+        assertThat(fixture.body).isNull()
+        assertThat(fixture.connectionFailure).isFalse
+        assertThat(fixture.timeoutFailure).isTrue
     }
 
     @Test

--- a/dispatcher/src/test/resources/fixtures/timeout_failure.yaml
+++ b/dispatcher/src/test/resources/fixtures/timeout_failure.yaml
@@ -1,0 +1,4 @@
+statusCode: 200
+headers:
+  - 'Content-Type: text/plain'
+timeoutFailure:  true


### PR DESCRIPTION
Hello 👋

In this PR, I added the possibility to force the request to fail by a timeout response.

This is very useful when we test timeout scenarios during UI tests.

You only need to specify a new parameter in the YAML file called `timeoutFailure`.

```
statusCode : 200
timeoutFailure: true
```