### PR TITLE
PathQueryCondition for multiple query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 1.1.7 - 01.08.2023
+
+- Expand `PathQueryCondition` to enable matching requests on multiple query parameters (per issue [#16](https://github.com/DroidsOnRoids/mockwebserver-path-dispatcher/issues/16))
+- Compatibility is maintained with previous versions
+
+### 1.1.6 - 09.01.2023
+
+- Add option to mock timeout failure
+
 ### 1.1.5 - 01.12.2022
 
 - Make FixtureDispatcher thread-safe

--- a/README.md
+++ b/README.md
@@ -126,6 +126,11 @@ fun factory() {
     dispatcher.putResponse(factory.withPathSuffixAndQueryParameter("suffix", "param"), "response_with_query_parameter")
     // match all URLs with path ending with "suffix" and have "param" with "value" as query parameter e.g. http://example.test/prefix/user/suffix?param=value
     dispatcher.putResponse(factory.withPathSuffixAndQueryParameter("suffix", "param", "value"), "response_with_query_parameter_and_value")
+    // match all URLs with path ending with "suffix" and have multiple parameter name/value pairs e.g.http://example.test/prefix/user/suffix?param=value&param2=value2
+    dispatcher.putResponse(
+        factory.withPathSuffixAndQueryParameters("suffix", mapOf("param" to "value", "param2" to "value2")),
+        "response_with_multiple_query_parameters"
+    )
     mockWebServer.setDispatcher(dispatcher)
 }
 ```
@@ -138,6 +143,15 @@ fun pathQueryCondition() {
     dispatcher.putResponse(PathQueryCondition("/prefix/suffix", "param", "value"), "response_with_query_parameter_and_value")
     mockWebServer.setDispatcher(dispatcher)
     
+}
+```
+Also supports a map of multiple query parameters:
+
+```kotlin
+fun pathQueryConditions() {
+    val dispatcher = FixtureDispatcher()
+    dispatcher.putResponse(PathQueryCondition("/prefix/suffix", mapOf("param" to "value", "param2" to "value2")), "response_with_query_parameters_and_values")
+    mockWebServer.setDispatcher(dispatcher)
 }
 ```
 
@@ -175,13 +189,13 @@ fun condition() {
 For unit tests:
 
 ```gradle
-testImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.1.1'
+testImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.1.7'
 ```
 
 or for Android instrumentation tests:
 
 ```gradle
-androidTestImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.1.1'
+androidTestImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.1.7'
 ```
 
 ### License

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/PathQueryConditionFactory.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/PathQueryConditionFactory.kt
@@ -8,11 +8,32 @@ package pl.droidsonroids.testing.mockwebserver.condition
  */
 class PathQueryConditionFactory constructor(private val pathPrefix: String = "") {
     /**
+     * Creates condition with <code>path</code> and a <code>Map</code> of one or more query parameter name/value pairs.
+     * @param pathSuffix path suffix, may be empty
+     * @param queryParameters <code>Map</code> of query parameter name/value pairs
+     * @param httpMethod optional HTTPMethod for matching, defaults to HTTPMethod.ANY
+     * @return a PathQueryCondition
+     * @since 1.1.7
+     */
+    @JvmOverloads
+    fun withPathSuffixAndQueryParameters(
+        pathSuffix: String,
+        queryParameters: Map<String, String?>,
+        httpMethod: HTTPMethod = HTTPMethod.ANY
+    ) =
+        PathQueryCondition(
+            pathPrefix + pathSuffix,
+            httpMethod,
+            queryParameters
+        )
+
+    /**
      * Creates condition with both <code>path</code>, <code>queryParameterName</code>
      * and <code>queryParameterValue</code>.
      * @param pathSuffix path suffix, may be empty
      * @param queryParameterName query parameter name <code>queryParameterName</code>
      * @param queryParameterValue query parameter value for given
+     * @param httpMethod optional HTTPMethod for matching, defaults to HTTPMethod.ANY
      * @return a PathQueryCondition
      * @since 1.1.0
      */
@@ -33,6 +54,7 @@ class PathQueryConditionFactory constructor(private val pathPrefix: String = "")
     /**
      * Creates condition with <code>path</code> only.
      * @param pathSuffix path suffix, may be empty
+     * @param httpMethod optional HTTPMethod for matching, defaults to HTTPMethod.ANY
      * @return a PathQueryCondition
      * @since 1.1.0
      */
@@ -48,6 +70,7 @@ class PathQueryConditionFactory constructor(private val pathPrefix: String = "")
     /**
      * Creates condition with <code>path</code> only.
      * @param path the path
+     * @param httpMethod optional HTTPMethod for matching, defaults to HTTPMethod.ANY
      * @return a PathQueryCondition
      */
     fun withPath(

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/PathQueryConditionTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/PathQueryConditionTest.kt
@@ -14,11 +14,18 @@ import pl.droidsonroids.testing.mockwebserver.condition.PathQueryConditionFactor
 private const val INFIX = "/suffix"
 private const val PARAMETER_NAME = "param"
 private const val PARAMETER_VALUE = "value"
+private const val PARAMETER_NAME2 = "param2"
+private const val PARAMETER_VALUE2 = "value2"
+private val PARAMETER_MAP_SINGLE = mapOf(PARAMETER_NAME to PARAMETER_VALUE)
+private val PARAMETER_MAP_MULTIPLE_NULL = mapOf(PARAMETER_NAME to PARAMETER_VALUE, PARAMETER_NAME2 to null)
+private val PARAMETER_MAP_MULTIPLE = mapOf(PARAMETER_NAME to PARAMETER_VALUE, PARAMETER_NAME2 to PARAMETER_VALUE2)
 
 class PathQueryConditionTest {
     private lateinit var suffixPathQueryCondition: PathQueryCondition
     private lateinit var parameterNamePathQueryCondition: PathQueryCondition
     private lateinit var parameterValuePathQueryCondition: PathQueryCondition
+    private lateinit var parameterMapPathQueryCondition: PathQueryCondition
+    private lateinit var parameterMapNullPathQueryCondition: PathQueryCondition
 
     @Before
     fun setUp() {
@@ -28,6 +35,10 @@ class PathQueryConditionTest {
             factory.withPathSuffixAndQueryParameter(INFIX, PARAMETER_NAME)
         parameterValuePathQueryCondition =
             factory.withPathSuffixAndQueryParameter(INFIX, PARAMETER_NAME, PARAMETER_VALUE)
+        parameterMapPathQueryCondition =
+            factory.withPathSuffixAndQueryParameters(INFIX, PARAMETER_MAP_MULTIPLE)
+        parameterMapNullPathQueryCondition =
+            factory.withPathSuffixAndQueryParameters(INFIX, PARAMETER_MAP_MULTIPLE_NULL)
     }
 
     @Test
@@ -38,14 +49,31 @@ class PathQueryConditionTest {
     @Test
     fun `has correct suffix and query parameter name`() {
         assertThat(parameterNamePathQueryCondition.path).isEqualTo(INFIX)
-        assertThat(parameterNamePathQueryCondition.queryParameterName).isEqualTo(PARAMETER_NAME)
+        assertThat(parameterNamePathQueryCondition.queryParameters.keys.first()).isEqualTo(PARAMETER_NAME)
     }
 
     @Test
     fun `has correct suffix and query parameter name and value`() {
         assertThat(parameterValuePathQueryCondition.path).isEqualTo(INFIX)
-        assertThat(parameterValuePathQueryCondition.queryParameterName).isEqualTo(PARAMETER_NAME)
-        assertThat(parameterValuePathQueryCondition.queryParameterValue).isEqualTo(PARAMETER_VALUE)
+        assertThat(parameterValuePathQueryCondition.queryParameters.entries.first().key).isEqualTo(PARAMETER_NAME)
+        assertThat(parameterValuePathQueryCondition.queryParameters.entries.first().value).isEqualTo(PARAMETER_VALUE)
+    }
+
+    @Test
+    fun `has correct suffix and query parameter names and values`() {
+        assertThat(parameterMapPathQueryCondition.path).isEqualTo(INFIX)
+        assertThat(parameterMapPathQueryCondition.queryParameters.keys).containsAll(
+            setOf(
+                PARAMETER_NAME,
+                PARAMETER_NAME2
+            )
+        )
+        assertThat(parameterMapPathQueryCondition.queryParameters.values).containsAll(
+            setOf(
+                PARAMETER_VALUE,
+                PARAMETER_VALUE2
+            )
+        )
     }
 
     @Test
@@ -61,6 +89,26 @@ class PathQueryConditionTest {
     @Test
     fun `is value less than suffix`() {
         assertThat(parameterValuePathQueryCondition).isLessThan(suffixPathQueryCondition)
+    }
+
+    @Test
+    fun `is map less than suffix`() {
+        assertThat(parameterMapPathQueryCondition).isLessThan(suffixPathQueryCondition)
+    }
+
+    @Test
+    fun `is map less than name`() {
+        assertThat(parameterMapPathQueryCondition).isLessThan(parameterNamePathQueryCondition)
+    }
+
+    @Test
+    fun `is map less than value`() {
+        assertThat(parameterMapPathQueryCondition).isLessThan(parameterValuePathQueryCondition)
+    }
+
+    @Test
+    fun `is map less than map null`() {
+        assertThat(parameterMapPathQueryCondition).isLessThan(parameterMapNullPathQueryCondition)
     }
 
     @Test
@@ -111,10 +159,68 @@ class PathQueryConditionTest {
     }
 
     @Test
+    fun `url with equal suffix, query parameter name and value does not match mapped`() {
+        PathQueryCondition("/suffix", "param", "value")
+        val url = "http://test.test/suffix?param=value".toHttpUrl()
+        assertThat(parameterMapPathQueryCondition.isUrlMatching(url)).isFalse
+    }
+
+    @Test
+    fun `url with equal suffix, query parameter names and values matches`() {
+        val url = "http://test.test/suffix?param=value&param2=value2".toHttpUrl()
+        assertThat(parameterMapPathQueryCondition.isUrlMatching(url)).isTrue
+    }
+
+    @Test
+    fun `url with equal suffix, first query parameter pair, different second parameter name does not match`() {
+        val url = "http://test.test/suffix?param=value&param3".toHttpUrl()
+        assertThat(parameterMapPathQueryCondition.isUrlMatching(url)).isFalse
+    }
+
+    @Test
+    fun `url with equal suffix, first query parameter pair and second parameter name, different second parameter value does not match`() {
+        val url = "http://test.test/suffix?param=value&param2=value3".toHttpUrl()
+        assertThat(parameterMapPathQueryCondition.isUrlMatching(url)).isFalse
+    }
+
+    @Test
+    fun `url with equal suffix, first query parameter pair and second parameter name, null second parameter value does not match`() {
+        val url = "http://test.test/suffix?param=value&param2".toHttpUrl()
+        assertThat(parameterMapPathQueryCondition.isUrlMatching(url)).isFalse
+    }
+
+    @Test
+    fun `url with equal suffix, first query parameter pair and second parameter name match when second parameter value null`() {
+        val url = "http://test.test/suffix?param=value&param2=value3".toHttpUrl()
+        assertThat(parameterMapNullPathQueryCondition.isUrlMatching(url)).isTrue
+    }
+
+    @Test
     fun `equals and hashCode match contract`() {
         EqualsVerifier
             .forClass(PathQueryCondition::class.java)
             .verify()
+    }
+
+    @Test
+    fun `alternate constructors yield equivalent results for map`() {
+        val withMethod = PathQueryCondition(INFIX, HTTPMethod.ANY, PARAMETER_MAP_MULTIPLE)
+        val withoutMethod = PathQueryCondition(INFIX, PARAMETER_MAP_MULTIPLE)
+        assertThat(withMethod.queryParameters).containsAllEntriesOf(withoutMethod.queryParameters)
+    }
+
+    @Test
+    fun `alternate constructors yield equivalent results for parameter name`() {
+        val withMethod = PathQueryCondition(INFIX, HTTPMethod.ANY, PARAMETER_NAME)
+        val withoutMethod = PathQueryCondition(INFIX, PARAMETER_NAME)
+        assertThat(withMethod.queryParameters).containsAllEntriesOf(withoutMethod.queryParameters)
+    }
+
+    @Test
+    fun `alternate constructors yield equivalent results for name and value`() {
+        val withMethod = PathQueryCondition(INFIX, HTTPMethod.ANY, PARAMETER_NAME, PARAMETER_VALUE)
+        val withoutMethod = PathQueryCondition(INFIX, PARAMETER_NAME, PARAMETER_VALUE)
+        assertThat(withMethod.queryParameters).containsAllEntriesOf(withoutMethod.queryParameters)
     }
 
     @Test
@@ -162,6 +268,17 @@ class PathQueryConditionTest {
             .withPathSuffix("/abc", HTTPMethod.ANY)
         val secondCondition = PathQueryConditionFactory()
             .withPathSuffix("/abc", HTTPMethod.GET)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(-1)
+    }
+
+    @Test
+    fun `compareTo should return -1 when first condition http method has higher precedence than second condition`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffix("/abc", HTTPMethod.GET)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffix("/abc", HTTPMethod.POST)
 
         assertThat(firstCondition.compareTo(secondCondition))
             .isEqualTo(-1)
@@ -231,5 +348,71 @@ class PathQueryConditionTest {
 
         assertThat(firstCondition.compareTo(secondCondition))
             .isEqualTo(1)
+    }
+
+    @Test
+    fun `compareTo should return 1 when the first condition does not have a parameter and the second one has a parameter value map`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffix("/abc")
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameters("/abc", PARAMETER_MAP_MULTIPLE)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `compareTo should return 1 when the first condition has a parameter name and the second one has a parameter value map`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameters("/abc", PARAMETER_MAP_MULTIPLE)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `compareTo should return 1 when the first condition has a parameter name and value and the second one has a parameter value map with multiple pairs`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME, PARAMETER_VALUE)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameters("/abc", PARAMETER_MAP_MULTIPLE)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `compareTo should return 0 when the first condition has a parameter name and value and the second one has a parameter value map with matching parameters`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME, PARAMETER_VALUE)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameters("/abc", PARAMETER_MAP_SINGLE)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(0)
+    }
+
+    @Test
+    fun `compareTo should return 1 when the first condition has a parameter value map with a null value and the second has a parameter value map with non-null values`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameters("/abc", PARAMETER_MAP_MULTIPLE_NULL)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameters("/abc", PARAMETER_MAP_MULTIPLE)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(1)
+    }
+
+    @Test
+    fun `compareTo should return -1 when the first condition has a parameter value map with non-null values and the second has a map with a null value`() {
+        val firstCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameters("/abc", PARAMETER_MAP_MULTIPLE)
+        val secondCondition = PathQueryConditionFactory()
+            .withPathSuffixAndQueryParameters("/abc", PARAMETER_MAP_MULTIPLE_NULL)
+
+        assertThat(firstCondition.compareTo(secondCondition))
+            .isEqualTo(-1)
     }
 }

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/PathQueryConditionTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/PathQueryConditionTest.kt
@@ -274,17 +274,6 @@ class PathQueryConditionTest {
     }
 
     @Test
-    fun `compareTo should return -1 when first condition http method has higher precedence than second condition`() {
-        val firstCondition = PathQueryConditionFactory()
-            .withPathSuffix("/abc", HTTPMethod.GET)
-        val secondCondition = PathQueryConditionFactory()
-            .withPathSuffix("/abc", HTTPMethod.POST)
-
-        assertThat(firstCondition.compareTo(secondCondition))
-            .isEqualTo(-1)
-    }
-
-    @Test
     fun `compareTo should return -1 when the first condition has a parameter name and the second one does not`() {
         val firstCondition = PathQueryConditionFactory()
             .withPathSuffixAndQueryParameter("/abc", PARAMETER_NAME)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=pl.droidsonroids.testing
-VERSION_NAME=1.1.5
+VERSION_NAME=1.1.7
 POM_INCEPTION_YEAR=2017
 POM_ARTIFACT_ID=mockwebserver-path-dispatcher
 POM_DESCRIPTION=Mockwebserver path dispatcher


### PR DESCRIPTION
I've come up with a solution for the enhancement proposed by ealanhill

- Expand `PathQueryCondition` to enable matching requests on multiple query parameters (per issue [#16](https://github.com/DroidsOnRoids/mockwebserver-path-dispatcher/issues/16))
- Compatibility is maintained with previous versions