### PR TITLE
Update snakeyaml to non-android 2.4

### DIFF
--- a/dispatcher/build.gradle.kts
+++ b/dispatcher/build.gradle.kts
@@ -11,7 +11,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib:1.5.31")
     implementation("com.squareup.okhttp3:mockwebserver:4.9.2")
     implementation("org.apache.commons:commons-text:1.9")
-    implementation("org.yaml:snakeyaml:1.29:android")
+    implementation("org.yaml:snakeyaml:2.4")
     testImplementation("org.assertj:assertj-core:3.21.0")
     testImplementation("com.nhaarman:mockito-kotlin:1.6.0")
     testImplementation("org.mockito:mockito-core:4.0.0")

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/Fixture.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/Fixture.kt
@@ -5,17 +5,11 @@ import okio.Buffer
 internal class Fixture {
 
     var statusCode = 0
-        internal set
     var body: String? = null
-        internal set
     var bodyContent: BodyContent? = null
-        internal set
     var headers: List<String> = emptyList()
-        internal set
     var connectionFailure: Boolean = false
-        internal set
     var timeoutFailure: Boolean = false
-        internal set
 
     internal fun hasJsonBody() = body?.isPossibleJson() ?: false
 }


### PR DESCRIPTION
Since 1.30, the android version is not available anymore, so we should use the regular version. This solves compatibility issues with other libraries that uses snakeyaml as using the android version forces resolving that variant.

When using this library with Robolectric for example, you can find issues like this:
> Could not find snakeyaml-2.3-android.jar (org.yaml:snakeyaml:2.3).
>  Searched in the following locations:
>      https://repo.maven.apache.org/maven2/org/yaml/snakeyaml/2.3/snakeyaml-2.3-android.jar