### PR TITLE
Set publish destination

### DIFF
--- a/dispatcher/build.gradle.kts
+++ b/dispatcher/build.gradle.kts
@@ -34,3 +34,8 @@ kotlin {
 
 group = property("GROUP") as String
 version = property("VERSION_NAME") as String
+
+mavenPublishing {
+    publishToMavenCentral()
+    signAllPublications()
+}


### PR DESCRIPTION
It looks like since `0.20.0` we need to specify where to publish the artifacts explicitly.
I hope this solves the publishing. Can you check it for me @koral-- as I'm not sure how do you provide the credentials?

Thanks!

Here's the changelog for reference.
https://github.com/vanniktech/gradle-maven-publish-plugin/blob/main/CHANGELOG.md#0200-2022-06-02

Fixes https://github.com/DroidsOnRoids/mockwebserver-path-dispatcher/issues/39