### PR TITLE
Migrate to OkHttp 5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 1.4.0 - 07.23.2025
+
+- Update OkHttp to 5.1.0
+
+#### Breaking changes
+
+- OkHttp 5.0.0+ is required.
+
 ### 1.3.0 - 04.25.2025
 
 - Update Kotlin to 2.1.20.

--- a/README.md
+++ b/README.md
@@ -243,13 +243,13 @@ fun transformResponseUrls() {
 For unit tests:
 
 ```gradle
-testImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.2.0'
+testImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.4.0'
 ```
 
 or for Android instrumentation tests:
 
 ```gradle
-androidTestImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.2.0'
+androidTestImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.4.0'
 ```
 
 ### License

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcher.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcher.kt
@@ -5,8 +5,10 @@ import mockwebserver3.MockResponse
 import mockwebserver3.RecordedRequest
 import pl.droidsonroids.testing.mockwebserver.condition.Condition
 import pl.droidsonroids.testing.mockwebserver.condition.PathQueryCondition
-import java.util.*
+import java.util.ArrayDeque
 import java.util.Collections.synchronizedSortedMap
+import java.util.Deque
+import java.util.TreeMap
 
 /**
  * The dispatcher using conditional fixture response mapping and enqueuing.

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcher.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcher.kt
@@ -1,8 +1,8 @@
 package pl.droidsonroids.testing.mockwebserver
 
-import okhttp3.mockwebserver.Dispatcher
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.RecordedRequest
+import mockwebserver3.Dispatcher
+import mockwebserver3.MockResponse
+import mockwebserver3.RecordedRequest
 import pl.droidsonroids.testing.mockwebserver.condition.Condition
 import pl.droidsonroids.testing.mockwebserver.condition.PathQueryCondition
 import java.util.*

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilder.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilder.kt
@@ -1,7 +1,7 @@
 package pl.droidsonroids.testing.mockwebserver
 
-import okhttp3.mockwebserver.MockResponse
-import okhttp3.mockwebserver.SocketPolicy
+import mockwebserver3.MockResponse
+import mockwebserver3.SocketEffect
 
 internal class MockResponseBuilder constructor(private val parser: ResourcesParser) :
     ResponseBuilder {
@@ -13,11 +13,11 @@ internal class MockResponseBuilder constructor(private val parser: ResourcesPars
     ): MockResponse {
         val fixture = parser.parseFrom(responseFixtureName)
 
-        val mockResponse = MockResponse()
-        mockResponse.setResponseCode(fixture.statusCode)
+        val mockResponseBuilder = MockResponse.Builder()
+        mockResponseBuilder.code(fixture.statusCode)
 
         fixture.headers.forEach {
-            mockResponse.addHeader(it)
+            mockResponseBuilder.addHeader(it)
         }
 
         val bodyContent = fixture.bodyContent?.let { bodyContent ->
@@ -25,27 +25,27 @@ internal class MockResponseBuilder constructor(private val parser: ResourcesPars
         }
         when (bodyContent) {
             is BodyContent.Text -> {
-                mockResponse.addHeader("Content-Type: text/plain")
-                mockResponse.setBody(bodyContent.content)
+                mockResponseBuilder.addHeader("Content-Type: text/plain")
+                mockResponseBuilder.body(bodyContent.content)
             }
             is BodyContent.Json -> {
-                mockResponse.addHeader("Content-Type: application/json")
-                mockResponse.setBody(bodyContent.content)
+                mockResponseBuilder.addHeader("Content-Type: application/json")
+                mockResponseBuilder.body(bodyContent.content)
             }
-            is BodyContent.Binary -> mockResponse.setBody(bodyContent.content)
+            is BodyContent.Binary -> mockResponseBuilder.body(bodyContent.content)
             null -> Unit
         }
 
         when {
             fixture.connectionFailure -> {
-                mockResponse.socketPolicy = SocketPolicy.DISCONNECT_AT_START
+                mockResponseBuilder.onRequestStart(SocketEffect.ShutdownConnection)
             }
 
             fixture.timeoutFailure -> {
-                mockResponse.socketPolicy = SocketPolicy.NO_RESPONSE
+                mockResponseBuilder.onResponseStart(SocketEffect.Stall)
             }
         }
 
-        return mockResponse
+        return mockResponseBuilder.build()
     }
 }

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/ResponseBuilder.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/ResponseBuilder.kt
@@ -1,6 +1,6 @@
 package pl.droidsonroids.testing.mockwebserver
 
-import okhttp3.mockwebserver.MockResponse
+import mockwebserver3.MockResponse
 
 internal interface ResponseBuilder {
     fun buildMockResponse(

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/Condition.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/Condition.kt
@@ -1,6 +1,6 @@
 package pl.droidsonroids.testing.mockwebserver.condition
 
-import okhttp3.mockwebserver.RecordedRequest
+import mockwebserver3.RecordedRequest
 
 /**
  * Represents set of mocked request properties which have to match received request.

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/HttpUrlCondition.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/condition/HttpUrlCondition.kt
@@ -1,7 +1,7 @@
 package pl.droidsonroids.testing.mockwebserver.condition
 
+import mockwebserver3.RecordedRequest
 import okhttp3.HttpUrl
-import okhttp3.mockwebserver.RecordedRequest
 
 /**
  * A Condition which matches HttpUrls only, they are extracted from request so that only
@@ -16,10 +16,7 @@ abstract class HttpUrlCondition : Condition {
             return false
         }
 
-        return when (val url = request.requestUrl) {
-            null -> false
-            else -> isUrlMatching(url)
-        }
+        return isUrlMatching(request.url)
     }
 
     /**

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherIntegrationTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherIntegrationTest.kt
@@ -1,9 +1,9 @@
 package pl.droidsonroids.testing.mockwebserver
 
+import mockwebserver3.junit4.MockWebServerRule
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Rule
 import org.junit.Test
@@ -11,7 +11,9 @@ import pl.droidsonroids.testing.mockwebserver.condition.PathQueryConditionFactor
 
 class FixtureDispatcherIntegrationTest {
     @get:Rule
-    val mockWebServer = MockWebServer()
+    val mockWebServerRule = MockWebServerRule()
+    val mockWebServer by lazy { mockWebServerRule.server }
+
 
     @Test
     fun `response dispatched with mockwebserver`() {

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherTest.kt
@@ -4,19 +4,32 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import mockwebserver3.RecordedRequest
 import okhttp3.Headers
-import okhttp3.mockwebserver.RecordedRequest
-import okio.Buffer
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okio.ByteString
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
-import java.net.Socket
 
 class FixtureDispatcherTest {
     private lateinit var dispatcher: FixtureDispatcher
     private lateinit var responseBuilder: ResponseBuilder
     private val request =
-        RecordedRequest("", Headers.headersOf(), emptyList(), 0, Buffer(), 0, Socket())
+        RecordedRequest(
+            connectionIndex = 0,
+            headers = Headers.headersOf(),
+            chunkSizes = emptyList(),
+            bodySize = 0,
+            body = ByteString.EMPTY,
+            exchangeIndex = 0,
+            handshake = null,
+            handshakeServerNames = emptyList(),
+            method = "",
+            target = "",
+            version = "",
+            url = "http://localhost:8080".toHttpUrl(),
+        )
 
     @Before
     fun setUp() {

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FixtureDispatcherTest.kt
@@ -1,9 +1,5 @@
 package pl.droidsonroids.testing.mockwebserver
 
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.verify
 import mockwebserver3.RecordedRequest
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -11,6 +7,10 @@ import okio.ByteString
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 
 class FixtureDispatcherTest {
     private lateinit var dispatcher: FixtureDispatcher

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FunctionalTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/FunctionalTest.kt
@@ -1,8 +1,8 @@
 package pl.droidsonroids.testing.mockwebserver
 
+import mockwebserver3.junit4.MockWebServerRule
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.mockwebserver.MockWebServer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Rule
@@ -17,9 +17,9 @@ private const val TEST_JSON_ARRAY = "[ ]"
 
 class FunctionalTest {
 
-    @JvmField
-    @Rule
-    val mockWebServer = MockWebServer()
+    @get:Rule
+    val mockWebServerRule = MockWebServerRule()
+    val mockWebServer by lazy { mockWebServerRule.server }
 
     private var port: Int = 0
     private lateinit var client: OkHttpClient

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
@@ -3,7 +3,8 @@ package pl.droidsonroids.testing.mockwebserver
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import okhttp3.mockwebserver.SocketPolicy
+import mockwebserver3.MockResponseBody
+import mockwebserver3.SocketEffect
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -28,8 +29,8 @@ internal class MockResponseBuilderTest {
         fixture.bodyContent = BodyContent.Text(body)
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.status).contains("200")
-        assertThat(mockResponse.getBody()?.readUtf8()).isEqualTo(body)
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.body?.readUtf8()).isEqualTo(body)
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
@@ -38,8 +39,8 @@ internal class MockResponseBuilderTest {
         fixture.bodyContent = BodyContent.Binary(Buffer().writeUtf8(body))
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.status).contains("200")
-        assertThat(mockResponse.getBody()?.readByteArray()).isEqualTo(body.toByteArray())
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.body?.readByteArray()).isEqualTo(body.toByteArray())
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
@@ -48,8 +49,8 @@ internal class MockResponseBuilderTest {
         fixture.body = body
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.status).contains("200")
-        assertThat(mockResponse.getBody()?.readUtf8()).isNull()
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.body).isNull()
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
@@ -60,8 +61,8 @@ internal class MockResponseBuilderTest {
             BodyContent.Json("transformed body")
         }
         assertThat(mockResponse.status).contains("200")
-        assertThat(mockResponse.getBody()?.readUtf8()).isEqualTo("transformed body")
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.body?.readUtf8()).isEqualTo("transformed body")
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
@@ -70,10 +71,10 @@ internal class MockResponseBuilderTest {
         fixture.headers = listOf("name:value", "name2:value2")
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.status).contains("400")
-        assertThat(mockResponse.getBody()).isNull()
+        assertThat(mockResponse.body).isNull()
         assertThat(mockResponse.headers["name"]).isEqualTo("value")
         assertThat(mockResponse.headers["name2"]).isEqualTo("value2")
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
@@ -82,7 +83,7 @@ internal class MockResponseBuilderTest {
         fixture.bodyContent = BodyContent.Text("text")
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.headers["Content-Type"]).isEqualTo("text/plain")
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
@@ -91,7 +92,7 @@ internal class MockResponseBuilderTest {
         fixture.bodyContent = BodyContent.Json("""{"text"}""")
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.headers["Content-Type"]).isEqualTo("application/json")
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
@@ -100,7 +101,7 @@ internal class MockResponseBuilderTest {
         fixture.bodyContent = BodyContent.Text("text")
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.headers["Content-Type"]).isEqualTo("text/plain")
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
@@ -109,26 +110,38 @@ internal class MockResponseBuilderTest {
         fixture.bodyContent = BodyContent.Json("""{"text"}""")
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.headers["Content-Type"]).isEqualTo("application/json")
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.KEEP_OPEN)
+        assertThat(mockResponse.onRequestStart).isNull()
     }
 
     @Test
-    fun `DISCONNECT_AT_START set when connection failure is true`() {
+    fun `Should shutdown connection when connection failure is true`() {
         fixture.statusCode = 200
         fixture.connectionFailure = true
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.status).contains("200")
-        assertThat(mockResponse.getBody()).isNull()
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.DISCONNECT_AT_START)
+        assertThat(mockResponse.body).isNull()
+        assertThat(mockResponse.onRequestStart).isEqualTo(SocketEffect.ShutdownConnection)
     }
 
     @Test
-    fun `NO_RESPONSE set when timeout failure is true`() {
+    fun `Should not process response when timeout failure is true`() {
         fixture.statusCode = 200
         fixture.timeoutFailure = true
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.status).contains("200")
-        assertThat(mockResponse.getBody()).isNull()
-        assertThat(mockResponse.socketPolicy).isEqualTo(SocketPolicy.NO_RESPONSE)
+        assertThat(mockResponse.body).isNull()
+        assertThat(mockResponse.onResponseStart).isEqualTo(SocketEffect.Stall)
+    }
+
+    private fun MockResponseBody.readUtf8(): String? =
+        writeToSink().readUtf8()
+
+    private fun MockResponseBody.readByteArray(): ByteArray =
+        writeToSink().readByteArray()
+
+    private fun MockResponseBody.writeToSink(): Buffer {
+        val sink = Buffer()
+        writeTo(sink)
+        return sink
     }
 }

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
@@ -1,14 +1,14 @@
 package pl.droidsonroids.testing.mockwebserver
 
-import org.mockito.kotlin.any
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
 import mockwebserver3.MockResponseBody
 import mockwebserver3.SocketEffect
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 
 internal class MockResponseBuilderTest {
     private val body = "body"

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/condition/HttpUrlConditionTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/condition/HttpUrlConditionTest.kt
@@ -1,39 +1,17 @@
 package pl.droidsonroids.testing.mockwebserver.condition
 
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.whenever
+import mockwebserver3.RecordedRequest
 import okhttp3.Headers
 import okhttp3.HttpUrl
-import okhttp3.mockwebserver.RecordedRequest
-import okio.Buffer
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.mockito.Spy
 import org.mockito.junit.MockitoJUnitRunner
-import java.net.Socket
 
 @RunWith(MockitoJUnitRunner::class)
 class HttpUrlConditionTest {
-    @Spy private val socket = Socket()
-
-    @Before
-    fun setUp() {
-        whenever(socket.localPort).doReturn(8080)
-    }
-
-    @Test
-    fun `request without URL does not match`() {
-        val matchAllUrlCondition = object : HttpUrlCondition() {
-            override fun isUrlMatching(url: HttpUrl) = true
-            override fun compareTo(other: Condition) = 0
-        }
-        val request =
-            RecordedRequest("", Headers.headersOf(), emptyList(), 0, Buffer(), 0, socket)
-
-        assertThat(matchAllUrlCondition.isRequestMatching(request)).isFalse
-    }
 
     @Test
     fun `request with different HTTP method does not match`() {
@@ -45,7 +23,20 @@ class HttpUrlConditionTest {
             override fun compareTo(other: Condition) = 0
         }
         val request =
-            RecordedRequest("GET /some/path HTTP/1.1", Headers.headersOf(), emptyList(), 0, Buffer(), 0, socket)
+            RecordedRequest(
+                connectionIndex = 0,
+                headers = Headers.headersOf(),
+                chunkSizes = emptyList(),
+                bodySize = 0,
+                body = ByteString.EMPTY,
+                exchangeIndex = 0,
+                handshake = null,
+                handshakeServerNames = emptyList(),
+                method = "GET",
+                target = "/some/path",
+                version = "HTTP/1.1",
+                url = "http://localhost:8080".toHttpUrl(),
+            )
 
         assertThat(matchAllUrlCondition.isRequestMatching(request)).isFalse
     }
@@ -60,7 +51,20 @@ class HttpUrlConditionTest {
             override fun compareTo(other: Condition) = 0
         }
         val request =
-            RecordedRequest("GET /some/path HTTP/1.1", Headers.headersOf(), emptyList(), 0, Buffer(), 0, socket)
+            RecordedRequest(
+                connectionIndex = 0,
+                headers = Headers.headersOf(),
+                chunkSizes = emptyList(),
+                bodySize = 0,
+                body = ByteString.EMPTY,
+                exchangeIndex = 0,
+                handshake = null,
+                handshakeServerNames = emptyList(),
+                method = "GET",
+                target = "/some/path",
+                version = "HTTP/1.1",
+                url = "http://localhost:8080".toHttpUrl(),
+            )
 
         assertThat(matchAllUrlCondition.isRequestMatching(request)).isTrue
     }
@@ -69,7 +73,7 @@ class HttpUrlConditionTest {
     fun `request with URL with any request method should match any request method`() {
         HTTPMethod.values()
             .filter { it != HTTPMethod.ANY }
-            .forEach { httpMethod->
+            .forEach { httpMethod ->
                 val matchAllUrlCondition = object : HttpUrlCondition() {
                     override val httpMethod: HTTPMethod
                         get() = HTTPMethod.ANY
@@ -78,7 +82,20 @@ class HttpUrlConditionTest {
                     override fun compareTo(other: Condition) = 0
                 }
                 val request =
-                    RecordedRequest("${httpMethod.name} /some/path HTTP/1.1", Headers.headersOf(), emptyList(), 0, Buffer(), 0, socket)
+                    RecordedRequest(
+                        connectionIndex = 0,
+                        headers = Headers.headersOf(),
+                        chunkSizes = emptyList(),
+                        bodySize = 0,
+                        body = ByteString.EMPTY,
+                        exchangeIndex = 0,
+                        handshake = null,
+                        handshakeServerNames = emptyList(),
+                        method = httpMethod.name,
+                        target = "/some/path",
+                        version = "HTTP/1.1",
+                        url = "http://localhost:8080".toHttpUrl(),
+                    )
 
                 assertThat(matchAllUrlCondition.isRequestMatching(request))
                     .withFailMessage { "${httpMethod.name} does not match condition" }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=pl.droidsonroids.testing
-VERSION_NAME=1.3.0
+VERSION_NAME=1.4.0
 POM_INCEPTION_YEAR=2017
 POM_ARTIFACT_ID=mockwebserver-path-dispatcher
 POM_DESCRIPTION=Mockwebserver path dispatcher

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "2.1.20"
 dokka = "2.0.0"
 mavenPublish = "0.31.0"
 
-mockwebserver = "4.12.0"
+mockwebserver = "5.1.0"
 commonsText = "1.13.1"
 snakeyaml = "2.4"
 
@@ -15,7 +15,7 @@ equalsverifier = "3.19.3"
 jacoco = "0.8.13"
 
 [libraries]
-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "mockwebserver" }
+mockwebserver = { module = "com.squareup.okhttp3:mockwebserver3-junit4", version.ref = "mockwebserver" }
 commons-text = { module = "org.apache.commons:commons-text", version.ref = "commonsText" }
 snakeyaml = { module = "org.yaml:snakeyaml", version.ref = "snakeyaml" }
 


### PR DESCRIPTION
Migrate to OkHttp 5.1.0 so we can use it in apps that use that version. The migration is necessary as there are a couple of breaking changes.

The library hasn't changed much, but maybe the trickiest point is the `SocketPolicy` to `SocketEffect` migration.