### PR TITLE
Fix failures SocketEffect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 1.4.1 - 07.29.2025
+
+- Fix connection failure SocketEffect.
+
 ### 1.4.0 - 07.23.2025
 
 - Update OkHttp to 5.1.0

--- a/README.md
+++ b/README.md
@@ -243,13 +243,13 @@ fun transformResponseUrls() {
 For unit tests:
 
 ```gradle
-testImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.4.0'
+testImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.4.1'
 ```
 
 or for Android instrumentation tests:
 
 ```gradle
-androidTestImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.4.0'
+androidTestImplementation 'pl.droidsonroids.testing:mockwebserver-path-dispatcher:1.4.1'
 ```
 
 ### License

--- a/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilder.kt
+++ b/dispatcher/src/main/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilder.kt
@@ -38,7 +38,7 @@ internal class MockResponseBuilder constructor(private val parser: ResourcesPars
 
         when {
             fixture.connectionFailure -> {
-                mockResponseBuilder.onRequestStart(SocketEffect.ShutdownConnection)
+                mockResponseBuilder.onRequestStart(SocketEffect.CloseSocket())
             }
 
             fixture.timeoutFailure -> {

--- a/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
+++ b/dispatcher/src/test/kotlin/pl/droidsonroids/testing/mockwebserver/MockResponseBuilderTest.kt
@@ -120,7 +120,9 @@ internal class MockResponseBuilderTest {
         val mockResponse = builder.buildMockResponse("")
         assertThat(mockResponse.status).contains("200")
         assertThat(mockResponse.body).isNull()
-        assertThat(mockResponse.onRequestStart).isEqualTo(SocketEffect.ShutdownConnection)
+        assertThat(mockResponse.onRequestStart)
+            .usingRecursiveComparison()
+            .isEqualTo(SocketEffect.CloseSocket())
     }
 
     @Test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=pl.droidsonroids.testing
-VERSION_NAME=1.4.0
+VERSION_NAME=1.4.1
 POM_INCEPTION_YEAR=2017
 POM_ARTIFACT_ID=mockwebserver-path-dispatcher
 POM_DESCRIPTION=Mockwebserver path dispatcher


### PR DESCRIPTION
Fix wrong effect when migrating to MockWebServer3.

These are the correct mappings:
https://github.com/square/okhttp/pull/8870/files#diff-6d9d77bca7f869a9ad9d10c97223e5611bb6ccc1b330011679dec2d7851c5e52R60

Sorry for the noise @koral-- 🙏 